### PR TITLE
Constrain player object rotation on x and z axis

### DIFF
--- a/SGoopas/Assets/_Scenes/Game/GameMain.unity
+++ b/SGoopas/Assets/_Scenes/Game/GameMain.unity
@@ -1092,7 +1092,7 @@ Rigidbody:
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 0
+  m_Constraints: 80
   m_CollisionDetection: 0
 --- !u!23 &1886843204
 MeshRenderer:


### PR DESCRIPTION
Prevents player object from being flung around or falling over (particularly an issue while lifting objects)

Merge after previous 3dIntegration PRs