### PR TITLE
[LightRewire-1] Rewire of shadow structure

### DIFF
--- a/SGoopas/Assets/Scripts/Game/Shadow/DynamicShadowController.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/DynamicShadowController.cs
@@ -8,18 +8,17 @@ public class DynamicShadowController : ShadowController {
     private Vector3 linearVelocity;
     private Vector3 angularVelocity;
 
-    public override void Start()
-    {
-        base.Start();
+	public override void ConfigureWithLightParams(Light shadowLight, GameObject shadowPlane) { 
+		// Wait until we get the light params from above to construct the shadow.
+		base.ConfigureWithLightParams (shadowLight, shadowPlane);
+		rb = gameObject.GetComponent<Rigidbody>();
+		linearVelocity = new Vector3();
+		angularVelocity = new Vector3();
+	}
 
-        rb = gameObject.GetComponent<Rigidbody>();
-        linearVelocity = new Vector3();
-        angularVelocity = new Vector3();
-    }
-
-    public override void SwitchTo2D()
+    public override void ConstructShadow()
     {
-        base.SwitchTo2D();
+        base.ConstructShadow();
 
         linearVelocity = rb.velocity;
         rb.velocity = new Vector3();
@@ -31,9 +30,9 @@ public class DynamicShadowController : ShadowController {
         shadowCaster.CreateShadow();
     }
 
-    public override void SwitchTo3D()
+    public override void DeconstructShadow()
     {
-        base.SwitchTo3D();
+        base.DeconstructShadow();
 
         rb.isKinematic = false;
 

--- a/SGoopas/Assets/Scripts/Game/Shadow/GroupShadowHandler.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/GroupShadowHandler.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GroupShadowHandler : MonoBehaviour {
+	public GameObject shadowObjectsParent;
+
+	// Be explicit with reference to the light in the editor.
+	public Light shadowLight;
+	public GameObject shadowPlane;
+
+	public void Start() {
+		foreach (ShadowController shadowController in shadowObjectsParent.GetComponentsInChildren<ShadowController>()) {
+			shadowController.ConfigureWithLightParams(shadowLight, shadowPlane);
+		}
+	}
+
+	public void SwitchTo2D() {
+		foreach (ShadowController shadowController in shadowObjectsParent.GetComponentsInChildren<ShadowController>()) {
+			shadowController.ConstructShadow();
+		}
+	}
+
+	public void SwitchTo3D() { 
+		foreach (ShadowController shadowController in shadowObjectsParent.GetComponentsInChildren<ShadowController>()) {
+			shadowController.DeconstructShadow();
+		}
+	}
+}

--- a/SGoopas/Assets/Scripts/Game/Shadow/GroupShadowHandler.cs.meta
+++ b/SGoopas/Assets/Scripts/Game/Shadow/GroupShadowHandler.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 9f4fd2a36143e463aae71818a1f00e4b
+timeCreated: 1518804415
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SGoopas/Assets/Scripts/Game/Shadow/ShadowCaster.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/ShadowCaster.cs
@@ -4,11 +4,16 @@ using UnityEngine;
 
 public abstract class ShadowCaster : MonoBehaviour {
 
-    public Light shadowLight;
-    public GameObject shadowPlane;
+    protected Light shadowLight;
+    protected GameObject shadowPlane;
     protected GameObject shadow;
 
     public abstract void CreateShadow();
+
+	public void ConfigureWithLightParams(Light shadowLight, GameObject shadowPlane) {
+		this.shadowLight = shadowLight;
+		this.shadowPlane = shadowPlane;
+	}
 
     public void ShowShadow()
     {

--- a/SGoopas/Assets/Scripts/Game/Shadow/ShadowController.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/ShadowController.cs
@@ -7,20 +7,23 @@ public abstract class ShadowController : MonoBehaviour {
     protected MeshRenderer meshRenderer;
     protected ShadowCaster shadowCaster;
 
-    public virtual void Start()
-    {
-        meshRenderer = gameObject.GetComponent<MeshRenderer>();
-        shadowCaster = gameObject.GetComponent<ShadowCaster>();
-    }
+	/*
+	 * Sets up the initial parameters for the controller, called from the parent in the hierarchy.
+	 * All initialization code should go in here instead of start. 
+	 */
+	public virtual void ConfigureWithLightParams(Light shadowLight, GameObject shadowPlane) {
+		meshRenderer = gameObject.GetComponent<MeshRenderer>();
+		shadowCaster = gameObject.GetComponent<ShadowCaster>();
+		shadowCaster.ConfigureWithLightParams (shadowLight, shadowPlane);
+	}
 
-    public virtual void SwitchTo2D()
+	public virtual void ConstructShadow()
     {
         meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.ShadowsOnly;
     }
 
-    public virtual void SwitchTo3D()
+	public virtual void DeconstructShadow()
     {
         meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
     }
-
 }

--- a/SGoopas/Assets/Scripts/Game/Shadow/StaticShadowController.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/StaticShadowController.cs
@@ -3,24 +3,21 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class StaticShadowController : ShadowController {
+	public override void ConfigureWithLightParams(Light shadowLight, GameObject shadowPlane) { 
+		// Wait until we get the light params from above to construct the shadow.
+		base.ConfigureWithLightParams (shadowLight, shadowPlane);
+		shadowCaster.CreateShadow ();
+	}
 
-    public override void Start()
+    public override void ConstructShadow()
     {
-        base.Start();
-
-        shadowCaster.CreateShadow();
-    }
-
-    public override void SwitchTo2D()
-    {
-        base.SwitchTo2D();
-
+		base.ConstructShadow();
         shadowCaster.ShowShadow();
     }
 
-    public override void SwitchTo3D()
+    public override void DeconstructShadow()
     {
-        base.SwitchTo3D();
+        base.DeconstructShadow();
 
         shadowCaster.HideShadow();
     }

--- a/SGoopas/Assets/_Scenes/Game/GameMain.unity
+++ b/SGoopas/Assets/_Scenes/Game/GameMain.unity
@@ -168,8 +168,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!23 &89838732
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -279,8 +277,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!54 &94928960
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -349,37 +345,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 94928956}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1 &364535880
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 364535881}
-  m_Layer: 0
-  m_Name: 3DWalls
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &364535881
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 364535880}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1502755295}
-  - {fileID: 1805997894}
-  - {fileID: 789856168}
-  m_Father: {fileID: 1604130467}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &562374659
 GameObject:
   m_ObjectHideFlags: 0
@@ -504,8 +469,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!1 &664801367
 GameObject:
   m_ObjectHideFlags: 0
@@ -515,6 +478,7 @@ GameObject:
   m_Component:
   - component: {fileID: 664801368}
   - component: {fileID: 664801369}
+  - component: {fileID: 664801370}
   m_Layer: 0
   m_Name: Point light
   m_TagString: Untagged
@@ -571,6 +535,20 @@ Light:
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!114 &664801370
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 664801367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9f4fd2a36143e463aae71818a1f00e4b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shadowObjectsParent: {fileID: 751788782}
+  shadowLight: {fileID: 664801369}
+  shadowPlane: {fileID: 1387130232}
 --- !u!1 &686493301
 GameObject:
   m_ObjectHideFlags: 0
@@ -615,8 +593,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!23 &686493304
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -736,8 +712,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!23 &710670772
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -791,6 +765,68 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 710670768}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &751788782
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 751788783}
+  m_Layer: 0
+  m_Name: ObjectsWithShadows
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &751788783
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 751788782}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1699924562}
+  - {fileID: 1881638049}
+  - {fileID: 770367317}
+  m_Father: {fileID: 1604130467}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &770367316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 770367317}
+  m_Layer: 0
+  m_Name: Walls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &770367317
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 770367316}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1502755295}
+  - {fileID: 1805997894}
+  - {fileID: 789856168}
+  m_Father: {fileID: 751788783}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &789856167
 GameObject:
   m_ObjectHideFlags: 0
@@ -817,11 +853,11 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 789856167}
-  m_LocalRotation: {x: 0, y: 0.7071068, z: 0, w: 0.7071068}
-  m_LocalPosition: {x: 15.12, y: -0, z: -14.53}
-  m_LocalScale: {x: 0.5, y: 0.1, z: 50}
+  m_LocalRotation: {x: -0, y: 0.7071068, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 15.12, y: 0, z: -14.53}
+  m_LocalScale: {x: 0.50000024, y: 0.1, z: 50.00003}
   m_Children: []
-  m_Father: {fileID: 364535881}
+  m_Father: {fileID: 770367317}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
 --- !u!23 &789856169
@@ -899,8 +935,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!1 &810903889
 GameObject:
   m_ObjectHideFlags: 0
@@ -1025,8 +1059,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!1 &1364241755
 GameObject:
   m_ObjectHideFlags: 0
@@ -1204,8 +1236,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!1 &1387130232
 GameObject:
   m_ObjectHideFlags: 0
@@ -1319,7 +1349,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1392692859}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 46.36, y: 3.99, z: -36.948246}
+  m_LocalPosition: {x: 46.36, y: 3.9900002, z: -36.948246}
   m_LocalScale: {x: 1.4, y: 11, z: 2}
   m_Children: []
   m_Father: {fileID: 1881638049}
@@ -1347,8 +1377,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!23 &1392692863
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1430,7 +1458,7 @@ Transform:
   m_LocalPosition: {x: -10.2, y: 1, z: -7.45}
   m_LocalScale: {x: 0.5, y: 2, z: 15}
   m_Children: []
-  m_Father: {fileID: 364535881}
+  m_Father: {fileID: 770367317}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &1502755297
@@ -1541,8 +1569,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!23 &1520072828
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1709,9 +1735,7 @@ Transform:
   m_Children:
   - {fileID: 1538572200}
   - {fileID: 1886843201}
-  - {fileID: 1699924562}
-  - {fileID: 1881638049}
-  - {fileID: 364535881}
+  - {fileID: 751788783}
   m_Father: {fileID: 1934856849}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1913,8 +1937,8 @@ Transform:
   - {fileID: 562374660}
   - {fileID: 810903890}
   - {fileID: 94928957}
-  m_Father: {fileID: 1604130467}
-  m_RootOrder: 2
+  m_Father: {fileID: 751788783}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1805997893
 GameObject:
@@ -1944,7 +1968,7 @@ Transform:
   m_LocalPosition: {x: 40.25, y: 1, z: -7.45}
   m_LocalScale: {x: 0.5, y: 2, z: 15}
   m_Children: []
-  m_Father: {fileID: 364535881}
+  m_Father: {fileID: 770367317}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &1805997896
@@ -2031,8 +2055,8 @@ Transform:
   - {fileID: 710670769}
   - {fileID: 89838729}
   - {fileID: 1392692860}
-  m_Father: {fileID: 1604130467}
-  m_RootOrder: 3
+  m_Father: {fileID: 751788783}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1886843200
 GameObject:
@@ -2244,7 +2268,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1982187253}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -2.29, y: 8.07, z: -36.948246}
+  m_LocalPosition: {x: -2.2900004, y: 8.07, z: -36.948246}
   m_LocalScale: {x: 1.4, y: 19.5, z: 2}
   m_Children: []
   m_Father: {fileID: 1881638049}
@@ -2261,8 +2285,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ffd1ca9b04c824c4eaaf6b5d7dfc3115, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shadowLight: {fileID: 664801369}
-  shadowPlane: {fileID: 1387130232}
 --- !u!23 &1982187256
 MeshRenderer:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Shadow construction is now owned by the light (more specifically, GroupShadowHandler), not individual objects. Each object can still specify its own caster + controller (dynamic vs. static) combination, but parameters about the light and plane being used now sit at the top of the hierarchy.