### PR TITLE
[Danny-Level] Hide all 3D objects upon switch to 2D

### DIFF
--- a/SGoopas/Assets/Scripts/Game/Shadow/DynamicShadowController.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/DynamicShadowController.cs
@@ -23,8 +23,6 @@ public class DynamicShadowController : ShadowController {
 
     public override void ConstructShadow()
     {
-        base.ConstructShadow();
-
         //Freezes rigid body if one exists
         /*
             NOTE: with movable lights, objects without rigidbodies 
@@ -44,8 +42,6 @@ public class DynamicShadowController : ShadowController {
 
     public override void DeconstructShadow()
     {
-        base.DeconstructShadow();
-
         //Unfreezes rigid body if one exists
         if(rb != null){
             rb.isKinematic = false;

--- a/SGoopas/Assets/Scripts/Game/Shadow/GroupShadowHandler.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/GroupShadowHandler.cs
@@ -23,15 +23,38 @@ public class GroupShadowHandler : MonoBehaviour {
 	public void SwitchTo2D(Cancellable cancellable) {
 		foreach (ShadowController shadowController in shadowControllers) {
             cancellable.PerformCancellable(shadowController.ConstructShadow, shadowController.DeconstructShadow);
+            cancellable.PerformCancellable(HideShadowObjects, ShowShadowObjects);
 
             if (!cancellable.IsCancelled && !shadowController.IsShadowOkay(MainObjectContainer.Instance.Player2D))
                 cancellable.Cancel();
 		}
 	}
 
+    private void HideShadowObjects() {
+        foreach (MeshRenderer meshRenderer in shadowObjectsParent.GetComponentsInChildren<MeshRenderer>())
+        {
+            if (meshRenderer.gameObject.GetComponent<ShadowConfiguration>() != null)
+            {
+                meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.ShadowsOnly;
+            } else {
+                meshRenderer.enabled = false;
+            }
+        }
+    }
+
+    private void ShowShadowObjects() {
+        foreach (MeshRenderer meshRenderer in shadowObjectsParent.GetComponentsInChildren<MeshRenderer>())
+        {
+            meshRenderer.enabled = true;
+            meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
+        }
+    }
+
 	public void SwitchTo3D(Cancellable cancellable) { 
 		foreach (ShadowController shadowController in shadowControllers) {
-            cancellable.PerformCancellable(shadowController.DeconstructShadow, shadowController.ConstructShadow);
+                    cancellable.PerformCancellable(shadowController.DeconstructShadow, shadowController.ConstructShadow);
+                    cancellable.PerformCancellable(ShowShadowObjects, HideShadowObjects);
+           
         }
 	}
 

--- a/SGoopas/Assets/Scripts/Game/Shadow/RealtimeShadowController.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/RealtimeShadowController.cs
@@ -7,7 +7,6 @@ public class RealtimeShadowController : ShadowController {
 
 	public override void ConstructShadow()
 	{
-		base.ConstructShadow();
 		shadowCaster.CreateShadow();
 	}
 
@@ -21,7 +20,6 @@ public class RealtimeShadowController : ShadowController {
 
 	public override void DeconstructShadow()
 	{
-		base.DeconstructShadow();
 		shadowCaster.DestroyShadow();
 	}
 

--- a/SGoopas/Assets/Scripts/Game/Shadow/ShadowController.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/ShadowController.cs
@@ -12,20 +12,13 @@ public abstract class ShadowController {
 	public ShadowController(ShadowCaster caster, GameObject gameObject) {
 		shadowCaster = caster;
 		this.gameObject = gameObject;
-		this.meshRenderer = this.gameObject.GetComponent<MeshRenderer> ();
 	}
 
 	public abstract void UpdateShadow ();
 
     public abstract bool IsShadowOkay(GameObject player);
 
-    public virtual void ConstructShadow()
-    {
-        meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.ShadowsOnly;
-    }
+    public abstract void ConstructShadow();
 
-	public virtual void DeconstructShadow()
-    {
-        meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
-    }
+    public abstract void DeconstructShadow();
 }

--- a/SGoopas/Assets/Scripts/Game/Shadow/StaticShadowController.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/StaticShadowController.cs
@@ -9,8 +9,7 @@ public class StaticShadowController : ShadowController {
 
     public override void ConstructShadow()
     {
-		base.ConstructShadow();
-        shadowCaster.ShowShadow();
+		shadowCaster.ShowShadow();
     }
 
     public override bool IsShadowOkay(GameObject player)
@@ -20,8 +19,6 @@ public class StaticShadowController : ShadowController {
 
     public override void DeconstructShadow()
     {
-        base.DeconstructShadow();
-
         shadowCaster.HideShadow();
     }
 


### PR DESCRIPTION
Handle mesh hiding in the GroupShadowHandler instead of ShadowController, that way non-shadow-casting objects still can get hidden on the switch. This is critical for developing the wall level.