### PR TITLE
[Urgent Bug Fixes - 2] Fix issue with changing levels and static shadows

### DIFF
--- a/SGoopas/Assets/Scripts/Game/Shadow/ShadowCaster.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/ShadowCaster.cs
@@ -32,8 +32,12 @@ public abstract class ShadowCaster {
 
     public void ShowShadow()
     {
-        if (shadow != null)
+        if (shadow == null)
         {
+            // You can call ShowShadow without having to call CreateShadow.
+            // This allows for lazy initialization.
+            CreateShadow();
+        } else {
             shadow.SetActive(true);
         }
     }

--- a/SGoopas/Assets/Scripts/Game/Shadow/StaticShadowController.cs
+++ b/SGoopas/Assets/Scripts/Game/Shadow/StaticShadowController.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class StaticShadowController : ShadowController {
-	public StaticShadowController(ShadowCaster caster, GameObject gameObject) : base(caster, gameObject) {
-		shadowCaster.CreateShadow ();
-	}
+	public StaticShadowController(ShadowCaster caster, GameObject gameObject) : base(caster, gameObject) {}
 
     public override void ConstructShadow()
     {


### PR DESCRIPTION
Static shadows weren't being generated properly during a level switch because the constructor was getting called mid-scene-switch. Instead, lazily initialize static shadows by only creating them when they need to be shown. This will ensure they're never created mid-scene-switch.