### PR TITLE
[Urgent Bug Fixes - 3] Fixed death bug when switching levels

### DIFF
--- a/SGoopas/Assets/Scripts/Game/Controller/MasterPlayerStateMachine.cs
+++ b/SGoopas/Assets/Scripts/Game/Controller/MasterPlayerStateMachine.cs
@@ -30,12 +30,8 @@ namespace PlayerStates
             state2D = new StationaryRight2D(player2D, this, groundCheck);
             state2D.StoreState();
             currentState = state3D;
+            PlayerDeathHandler.ResetDeathEvent();
             PlayerDeathHandler.PlayerDeathEvent += PlayerDeathOccurred;
-        }
-
-        ~MasterPlayerStateMachine() {
-            // Unsubscribe from death event when this object is destroyed.
-            PlayerDeathHandler.PlayerDeathEvent -= PlayerDeathOccurred;
         }
 
         public void PlayerDeathOccurred() {

--- a/SGoopas/Assets/Scripts/Game/Controller/MasterPlayerStateMachine.cs
+++ b/SGoopas/Assets/Scripts/Game/Controller/MasterPlayerStateMachine.cs
@@ -34,6 +34,12 @@ namespace PlayerStates
             PlayerDeathHandler.PlayerDeathEvent += PlayerDeathOccurred;
         }
 
+        ~MasterPlayerStateMachine()
+        {
+            // Unsubscribe from death event when this object is destroyed.
+            PlayerDeathHandler.PlayerDeathEvent -= PlayerDeathOccurred;
+        }
+
         public void PlayerDeathOccurred() {
             currentState.Death();
         }

--- a/SGoopas/Assets/Scripts/Game/PlayerDeathHandler.cs
+++ b/SGoopas/Assets/Scripts/Game/PlayerDeathHandler.cs
@@ -8,4 +8,7 @@ public class PlayerDeathHandler {
     public static void TriggerPlayerDeath() {
         PlayerDeathEvent();
     }
+    public static void ResetDeathEvent() {
+        PlayerDeathEvent = null;
+    }
 }


### PR DESCRIPTION
Post-mortem logic was broken when switching levels. It turns out this was an issue with the timing of constructors / destructors, similar to the problem in #150. It turns out that MasterPlayerStateMachine's destructor isn't called immediately after swapping scenes (garbage collection, yay!), so it can't be depended on to properly release stale subscriptions to a static event. The solution is to release them when the event needs to be used again (i.e. in the constructor).