### PR TITLE
Improved 2d ground check

### DIFF
--- a/SGoopas/Assets/Scripts/Game/2D/2D Player States/Base2DState.cs
+++ b/SGoopas/Assets/Scripts/Game/2D/2D Player States/Base2DState.cs
@@ -13,6 +13,7 @@ namespace PlayerStates
         private float dJumpForce = 1f;
         private float maxHoriSpeed = 1f;
         private float maxVertSpeed = 1f;
+        private const float boxCastHeight = 0.1f;
 
         protected Rigidbody2D rb;
         private Vector2 linearVelocity;
@@ -53,7 +54,7 @@ namespace PlayerStates
             rb = PlayerObject.GetComponent<Rigidbody2D>();
 
             anim = PlayerObject.GetComponent<Animator>();
-            characterWidth = PlayerObject.GetComponent<Collider2D>().bounds.size.x/1.2f;
+            characterWidth = PlayerObject.GetComponent<Collider2D>().bounds.size.x;
 
             linearVelocity = new Vector2();
             angularVelocity = 0.0f;
@@ -198,19 +199,8 @@ namespace PlayerStates
             get {
                 Vector3 playerPosition = PlayerObject.transform.position;
                 Vector3 ground = GroundCheck.position;
-                Vector3 tempVL = playerPosition;
-                Vector3 tempVR = playerPosition;
-                tempVL.x = playerPosition.x - (characterWidth / 2.0f);
-                tempVR.x = playerPosition.x + (characterWidth / 2.0f);
 
-                if (Physics2D.Linecast(playerPosition, ground, ~(1 << LayerMask.NameToLayer("Player"))) || Physics2D.Linecast(tempVL, ground, ~(1 << LayerMask.NameToLayer("Player"))) || Physics2D.Linecast(tempVR, ground, ~(1 << LayerMask.NameToLayer("Player"))))
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
+                return Physics2D.BoxCast(playerPosition, new Vector2(characterWidth, boxCastHeight), 0f, ground - playerPosition, (ground - playerPosition).magnitude, ~(1 << LayerMask.NameToLayer("Player")));
             }
         }
 

--- a/SGoopas/Assets/Scripts/Game/2D/GroundCheckDebug2D.cs
+++ b/SGoopas/Assets/Scripts/Game/2D/GroundCheckDebug2D.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GroundCheckDebug2D : MonoBehaviour {
+    #if UNITY_EDITOR
+    void OnDrawGizmos()
+    {
+        Collider2D parentCollider = gameObject.transform.parent.gameObject.GetComponent<Collider2D>();
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireCube(gameObject.transform.position, new Vector3(parentCollider.bounds.size.x, 0.1f, 0.1f));
+    }
+    #endif
+}

--- a/SGoopas/Assets/Scripts/Game/2D/GroundCheckDebug2D.cs.meta
+++ b/SGoopas/Assets/Scripts/Game/2D/GroundCheckDebug2D.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 760bbf3b28c6da74bb65194329f87d90
+timeCreated: 1523914672
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SGoopas/Assets/_Scenes/Player2DAnimated.prefab
+++ b/SGoopas/Assets/_Scenes/Player2DAnimated.prefab
@@ -39,6 +39,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 4743100882434422}
+  - component: {fileID: 114100460434292100}
   m_Layer: 8
   m_Name: GroundCheck
   m_TagString: Untagged
@@ -355,6 +356,17 @@ Animator:
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
+--- !u!114 &114100460434292100
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1422466671065378}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 760bbf3b28c6da74bb65194329f87d90, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114346495154319522
 MonoBehaviour:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
I decided to give the same treatment to our 2D ground check as I just gave to the 3D.

We're actually fairly lenient with the distance we cast at, so the fact that this detection hits everything under her instead of potentially missing some it might make some levels too easy, so we can adjust the groundcheck transform. 

To help with setting up the groundcheck, I added a script that will draw a gizmo to show you where the boxcast will end, so you can more accurately visualize what the player can jump on. If you turn gizmos during play in the editor, you can see if while testing a level too. Won't have any effect on the build.

This probably would have been nice to have earlier, but... *shrug*