### PR TITLE
[Bug Fix] Fix echo falls through ground

### DIFF
--- a/SGoopas/Assets/_Scenes/Player2DAnimated.prefab
+++ b/SGoopas/Assets/_Scenes/Player2DAnimated.prefab
@@ -120,7 +120,9 @@ PolygonCollider2D:
     - - {x: -4, y: -7.5}
       - {x: -4, y: 7}
       - {x: 4, y: 7}
+      - {x: -4, y: -7.5}
       - {x: 4, y: -7.5}
+      - {x: 4, y: 7.5}
 --- !u!95 &95221784832528712
 Animator:
   serializedVersion: 3


### PR DESCRIPTION
Echo falls through the ground for thin ground platforms. This fixes it by making the poly collider ever-so-slightly more complicated.

![](https://puu.sh/A4O5C/ed9a27187a.png)