### PR TITLE
Make animation part of constructor in states

### DIFF
--- a/SGoopas/Assets/Scripts/Game/2D/2D Player States/DeadState2D.cs
+++ b/SGoopas/Assets/Scripts/Game/2D/2D Player States/DeadState2D.cs
@@ -41,6 +41,7 @@ namespace PlayerStates
 
         public override void Update()
         {
+            Animator2D.updateGroundedParam(anim, true);
             SetState(new StationaryRight2D(this));
         }
     }

--- a/SGoopas/Assets/Scripts/Game/2D/2D Player States/JumpingLeft2D.cs
+++ b/SGoopas/Assets/Scripts/Game/2D/2D Player States/JumpingLeft2D.cs
@@ -8,9 +8,11 @@ namespace PlayerStates
     {
         public JumpingLeft2D(BasePlayerState previousState) : base(previousState) {
             MakeSpriteFaceLeft();
+            Animator2D.updateGroundedParam(anim, false);
         }
         public JumpingLeft2D(GameObject player, MasterPlayerStateMachine playerStateMachine, Transform groundCheck) : base(player, playerStateMachine, groundCheck) {
             MakeSpriteFaceLeft();
+            Animator2D.updateGroundedParam(anim, false);
         }
 
 
@@ -65,7 +67,6 @@ namespace PlayerStates
             if (IsGrounded)
             {
                 SetState(new MovingLeft2D(this));
-                Animator2D.updateGroundedParam(anim, true);
             }
             //Sets animator's x and y speeds for the animations to use
             Animator2D.updateXYParam(anim, rb);

--- a/SGoopas/Assets/Scripts/Game/2D/2D Player States/JumpingRight2D.cs
+++ b/SGoopas/Assets/Scripts/Game/2D/2D Player States/JumpingRight2D.cs
@@ -8,9 +8,11 @@ namespace PlayerStates
     {
         public JumpingRight2D(BasePlayerState previousState) : base(previousState) {
             MakeSpriteFaceRight();
+            Animator2D.updateGroundedParam(anim, false);
         }
         public JumpingRight2D(GameObject player, MasterPlayerStateMachine playerStateMachine, Transform groundCheck) : base(player, playerStateMachine, groundCheck) {
             MakeSpriteFaceRight();
+            Animator2D.updateGroundedParam(anim, false);
         }
 
 
@@ -64,7 +66,6 @@ namespace PlayerStates
             if (IsGrounded)
             {
                 SetState(new MovingRight2D(this));
-                Animator2D.updateGroundedParam(anim, true);
             }
             //Sets animator's x and y speeds for the animations to use
             Animator2D.updateXYParam(anim, rb);

--- a/SGoopas/Assets/Scripts/Game/2D/2D Player States/MovingLeft2D.cs
+++ b/SGoopas/Assets/Scripts/Game/2D/2D Player States/MovingLeft2D.cs
@@ -7,11 +7,13 @@ namespace PlayerStates
     public class MovingLeft2D : Base2DState
     {
         public MovingLeft2D(BasePlayerState previousState) : base(previousState) {
+            Animator2D.updateGroundedParam(anim, true);
             actionTaken = true;
             dash = true;
             dJump = true;
         }
         public MovingLeft2D(GameObject player, MasterPlayerStateMachine playerStateMachine, Transform groundCheck) : base(player, playerStateMachine, groundCheck) {
+            Animator2D.updateGroundedParam(anim, true);
             actionTaken = true;
         }
 
@@ -61,7 +63,6 @@ namespace PlayerStates
             if (!IsGrounded)
             {
                 SetState(new JumpingLeft2D(this));
-                Animator2D.updateGroundedParam(anim, false);
             }
             //Sets animator's x and y speeds for the animations to use
             Animator2D.updateXYParam(anim, rb);

--- a/SGoopas/Assets/Scripts/Game/2D/2D Player States/MovingRight2D.cs
+++ b/SGoopas/Assets/Scripts/Game/2D/2D Player States/MovingRight2D.cs
@@ -10,9 +10,11 @@ namespace PlayerStates
             actionTaken = true;
             dash = true;
             dJump = true;
+            Animator2D.updateGroundedParam(anim, true);
         }
         public MovingRight2D(GameObject player, MasterPlayerStateMachine playerStateMachine, Transform groundCheck) : base(player, playerStateMachine, groundCheck) {
             actionTaken = true;
+            Animator2D.updateGroundedParam(anim, true);
         }
 
         bool actionTaken;
@@ -61,7 +63,6 @@ namespace PlayerStates
             if (!IsGrounded)
             {
                 SetState(new JumpingRight2D(this));
-                Animator2D.updateGroundedParam(anim, false);
             }
             //Sets animator's x and y speeds for the animations to use
             Animator2D.updateXYParam(anim, rb);

--- a/SGoopas/Assets/Scripts/Game/2D/2D Player States/StationaryLeft2D.cs
+++ b/SGoopas/Assets/Scripts/Game/2D/2D Player States/StationaryLeft2D.cs
@@ -6,15 +6,15 @@ namespace PlayerStates
 {
     public class StationaryLeft2D : Base2DState
     {
-
-
         public StationaryLeft2D(BasePlayerState previousState) : base(previousState) {
+            Animator2D.updateGroundedParam(anim, true);
             MakeSpriteFaceLeft();
             rb.velocity = new Vector2(0, rb.velocity.y);
             dash = true;
             dJump = true;
         }
         public StationaryLeft2D(GameObject player, MasterPlayerStateMachine playerStateMachine, Transform groundCheck) : base(player, playerStateMachine, groundCheck) {
+            Animator2D.updateGroundedParam(anim, true);
             MakeSpriteFaceLeft();
             rb.velocity = new Vector2(0, rb.velocity.y);
         }
@@ -64,7 +64,6 @@ namespace PlayerStates
             if (!IsGrounded)
             {
                 SetState(new JumpingLeft2D(this));
-                Animator2D.updateGroundedParam(anim, false);
             }
             //Sets animator's x and y speeds for the animations to use
             Animator2D.updateXYParam(anim, rb);

--- a/SGoopas/Assets/Scripts/Game/2D/2D Player States/StationaryRight2D.cs
+++ b/SGoopas/Assets/Scripts/Game/2D/2D Player States/StationaryRight2D.cs
@@ -7,12 +7,14 @@ namespace PlayerStates
     public class StationaryRight2D : Base2DState
     {
         public StationaryRight2D(BasePlayerState previousState) : base(previousState) {
+            Animator2D.updateGroundedParam(anim, true);
             MakeSpriteFaceRight();
             rb.velocity = new Vector2(0, rb.velocity.y);
             dash = true;
             dJump = true;
         }
         public StationaryRight2D(GameObject player, MasterPlayerStateMachine playerStateMachine, Transform groundCheck) : base(player, playerStateMachine, groundCheck) {
+            Animator2D.updateGroundedParam(anim, true);
             MakeSpriteFaceRight();
             rb.velocity = new Vector2(0, rb.velocity.y);
         }
@@ -60,7 +62,6 @@ namespace PlayerStates
             if (!IsGrounded)
             {
                 SetState(new JumpingRight2D(this));
-                Animator2D.updateGroundedParam(anim, false);
             }
             //Sets animator's x and y speeds for the animations to use
             Animator2D.updateXYParam(anim, rb);


### PR DESCRIPTION
This prevents the animation state machine from misaligning with player state machine for uncommon state changes.

Fixes #205, the bug where Echo slides instead of walking immediately after returning from death.